### PR TITLE
Fixed a deadlock occurring when a lock is taken by 2 distinct buildsteps

### DIFF
--- a/master/buildbot/locks.py
+++ b/master/buildbot/locks.py
@@ -85,7 +85,7 @@ class BaseLock:
 
         # Find all waiters ahead of the requester in the wait queue
         for idx, waiter in enumerate(self.waiting):
-            if waiter[0] == requester:
+            if waiter[0] is requester:
                 w_index = idx
                 break
         else:
@@ -167,7 +167,7 @@ class BaseLock:
         d = defer.Deferred()
 
         # Are we already in the wait queue?
-        w = [i for i, w in enumerate(self.waiting) if w[0] == owner]
+        w = [i for i, w in enumerate(self.waiting) if w[0] is owner]
         if w:
             self.waiting[w[0]] = (owner, access, d)
         else:
@@ -178,7 +178,7 @@ class BaseLock:
         debuglog("%s stopWaitingUntilAvailable(%s)" % (self, owner))
         assert isinstance(access, LockAccess)
         assert (owner, access, d) in self.waiting
-        self.waiting = [w for w in self.waiting if w[0] != owner]
+        self.waiting = [w for w in self.waiting if w[0] is not owner]
 
     def isOwner(self, owner, access):
         return (owner, access) in self.owners


### PR DESCRIPTION
If a build factory has a buildstep with a lock, this will trigger a deadlock whenever 3 or more builds of this factory are started at the same time. The main reason is that BaseLock uses the == operator to compare the owners of a given lock. But if owners are BuildSteps, it doesn't work because they inherit from ComparableMixin (#d6c6b550), so two distinct BuildStep objects sharing the same properties will be considered as equal, although they are distinct Python objects: `b0 == b1` but `b0 is not b1`. Because of this, the first two buildsteps acquiring the lock were able to complete, but then the `waiting` list was empty and the remaining buildsteps were waiting forever. It was not possible to stop them with the `Stop` button of the web interface; only a master restart stopped them.
We use the `is` operator instead of `==` to fix this.